### PR TITLE
Add version to manifest.json

### DIFF
--- a/custom_components/govee/manifest.json
+++ b/custom_components/govee/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "govee",
   "name": "Govee LED strips",
+  "version": "0.1.6-beta.1",
   "config_flow": true,
   "documentation": "https://github.com/LaggAt/hacs-govee/blob/master/README.md",
   "issue_tracker": "https://github.com/LaggAt/hacs-govee/issues",


### PR DESCRIPTION
Fixes warning when starting Home Assistant (#14)