### PR TITLE
Remove govee.state entity

### DIFF
--- a/custom_components/govee/__init__.py
+++ b/custom_components/govee/__init__.py
@@ -22,13 +22,11 @@ PLATFORMS = ["light"]
 
 def setup(hass, config):
     """This setup does nothing, we use the async setup."""
-    hass.states.set("govee.state", "setup called")
     return True
 
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the Govee component."""
-    hass.states.async_set("govee.state", "async_setup called")
     hass.data[DOMAIN] = {}
     return True
 


### PR DESCRIPTION
This entity was useless and without a unique_id we had no way to remove it from the autogen dashboard.