### PR TITLE
Update manifest.json to fix HA compatability issues

### DIFF
--- a/custom_components/govee/manifest.json
+++ b/custom_components/govee/manifest.json
@@ -6,7 +6,7 @@
   "config_flow": true,
   "documentation": "https://github.com/LaggAt/hacs-govee/blob/master/README.md",
   "issue_tracker": "https://github.com/LaggAt/hacs-govee/issues",
-  "requirements": ["govee-api-laggat==0.2.2", "dacite==1.6.0"],
+  "requirements": ["govee-api-laggat==0.2.2", "dacite==1.8.0"],
   "iot_class": "cloud_polling",
   "ssdp": [],
   "zeroconf": [],


### PR DESCRIPTION
There are multiple HA integrations that require >= 1.7.0, your integration is currently below that and causing some errors for users.