### PR TITLE
Bumb requirement version for dacite GREATER than 1.8.0

### DIFF
--- a/custom_components/govee/manifest.json
+++ b/custom_components/govee/manifest.json
@@ -6,7 +6,7 @@
   "config_flow": true,
   "documentation": "https://github.com/LaggAt/hacs-govee/blob/master/README.md",
   "issue_tracker": "https://github.com/LaggAt/hacs-govee/issues",
-  "requirements": ["govee-api-laggat==0.2.2", "dacite>=1.8.1"],
+  "requirements": ["govee-api-laggat==0.2.2", "dacite>=1.8.0"],
   "iot_class": "cloud_polling",
   "ssdp": [],
   "zeroconf": [],

--- a/custom_components/govee/manifest.json
+++ b/custom_components/govee/manifest.json
@@ -6,7 +6,7 @@
   "config_flow": true,
   "documentation": "https://github.com/LaggAt/hacs-govee/blob/master/README.md",
   "issue_tracker": "https://github.com/LaggAt/hacs-govee/issues",
-  "requirements": ["govee-api-laggat==0.2.2", "dacite==1.6.0"],
+  "requirements": ["govee-api-laggat==0.2.2", "dacite>=1.8.1"],
   "iot_class": "cloud_polling",
   "ssdp": [],
   "zeroconf": [],


### PR DESCRIPTION
Similar PR to the other one already posted here. only difference though is, since I started to troubleshoot my problem with the Roborock integration, there was already a newer version of Dacite, the 1.8.1. 
HOWEVER, I did tried to explicitly ask for the newer version, which was also giving me some problems with roborock for some weird reason. 
So the actual fix now, is to ask on the requirements for a version GREATER than 1.8.0  `>=1.8.0` instead of pinning any specific version `==`. And letting the system deal with. I actually get the 1.8.1 installed anyway when I check with `pip show dacite`.
This way now, I have everything working, Govee and Roborock, everytime, surviving reboots.