### PR TITLE
Require dacite>=1.8.0

### DIFF
--- a/custom_components/govee/manifest.json
+++ b/custom_components/govee/manifest.json
@@ -8,7 +8,7 @@
   "homekit": {},
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/LaggAt/hacs-govee/issues",
-  "requirements": ["govee-api-laggat==0.2.2", "dacite==1.8.0"],
+  "requirements": ["govee-api-laggat==0.2.2", "dacite>=1.8.0"],
   "ssdp": [],
   "version": "2023.11.1",
   "zeroconf": []


### PR DESCRIPTION
Specify a greater-than dependency specification for dacite in order to not unnecessarily constrain other integrations that may want to use newer versions.