### PR TITLE
Fix color temp for lights

### DIFF
--- a/custom_components/govee/light.py
+++ b/custom_components/govee/light.py
@@ -293,19 +293,19 @@ class GoveeLightEntity(LightEntity):
         return self._device.brightness + 1
 
     @property
-    def color_temp(self):
+    def color_temp_kelvin(self):
         """Return the color_temp of the light."""
         return self._device.color_temp
 
     @property
     def min_color_temp_kelvin(self):
         """Return the coldest color_temp that this light supports."""
-        return COLOR_TEMP_KELVIN_MAX
+        return COLOR_TEMP_KELVIN_MIN
 
     @property
     def max_color_temp_kelvin(self):
         """Return the warmest color_temp that this light supports."""
-        return COLOR_TEMP_KELVIN_MIN
+        return COLOR_TEMP_KELVIN_MAX
 
     @property
     def extra_state_attributes(self):


### PR DESCRIPTION
- The min and max was reversed
- The color_temp_kelvin property should be used since its in kelvin not mireds

This caused a few issues for HomeKit users
https://github.com/home-assistant/core/issues/135222 https://github.com/home-assistant/core/issues/135401 https://github.com/home-assistant/core/issues/135358

Disclaimer: I don't use this integration and don't have any way to test this