### PR TITLE
Fix #234

### DIFF
--- a/custom_components/govee/__init__.py
+++ b/custom_components/govee/__init__.py
@@ -68,8 +68,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         await async_unload_entry(hass, entry)
         raise PlatformNotReady()
 
-    for component in PLATFORMS:
-        await hass.config_entries.async_forward_entry_setup(entry, component)
+    try:
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    except ImportError as exc:
+        logging.error("Platform not found ({}).".format(exc))
+        return False
 
     return True
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
     "name": "govee",
-    "homeassistant": "2023.11.2"
+    "homeassistant": "2025.6.0"
 }


### PR DESCRIPTION
Fixed by calling `async_forward_entry_setups` instead of `async_forward_entry_setup`, further changes to call inline with HA API changes to make it work under the new call, error logging for the call if it does fail