### PR TITLE
Fix/govee setup error

### DIFF
--- a/custom_components/govee/__init__.py
+++ b/custom_components/govee/__init__.py
@@ -69,7 +69,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         raise PlatformNotReady()
 
     for component in PLATFORMS:
-        await hass.config_entries.async_forward_entry_setup(entry, component)
+        await hass.config_entries.async_forward_entry_setups(entry, (component,))
 
     return True
 


### PR DESCRIPTION
🔧 Fix: Replace deprecated async_forward_entry_setup with async_forward_entry_setups
🐛 Problem
Home Assistant Core (from version 2024.x) removed the method async_forward_entry_setup.
This caused the following error when setting up the Govee integration:

AttributeError: 'ConfigEntries' object has no attribute 'async_forward_entry_setup'. Did you mean: 'async_forward_entry_setups'?
✅ Solution
In custom_components/govee/__init__.py, the call was updated:

await hass.config_entries.async_forward_entry_setup(entry, component)
was changed to:

await hass.config_entries.async_forward_entry_setups(entry, (component,))
The method name is now correct.

component is passed as a tuple, as required by the updated API.

🔗 References
Fixes #236

Related to Home Assistant 2024.x API changes

🧪 Testing
Integration loads without error

Entities are set up as expected

No more warnings or crashes in the log