### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/govee/__init__.py
+++ b/custom_components/govee/__init__.py
@@ -69,8 +69,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         raise PlatformNotReady()
 
     for component in PLATFORMS:
-        await hass.config_entries.async_forward_entry_setup(entry, component)
-
+        # await hass.config_entries.async_forward_entry_setup(entry, component)
+        await hass.config_entries.async_forward_entry_setups(entry, [component])
     return True
 
 


### PR DESCRIPTION
This patch restores compatibility with Home Assistant 2024.6+ (and possibly earlier versions where the deprecation became effective).

I’ve tested the fix successfully on Home Assistant OS running version 2025.6.x.