### PR TITLE
Fix: replace deprecated async_forward_entry_setup with async_forward_…

### DIFF
--- a/custom_components/govee/__init__.py
+++ b/custom_components/govee/__init__.py
@@ -69,7 +69,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         raise PlatformNotReady()
 
     for component in PLATFORMS:
-        await hass.config_entries.async_forward_entry_setup(entry, component)
+        await hass.config_entries.async_forward_entry_setups(entry, [component])
 
     return True
 


### PR DESCRIPTION
Home Assistant deprecated async_forward_entry_setup . This change updates the call to async_forward_entry_setups with the required list format.