### PR TITLE
!! New forked repository to replace as default in HACS !! 

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,7 @@
+Copyright 2021 Florian Lagg @LaggAt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,119 @@
+# 'Govee' integration
+
+The Govee integration allows you to control and monitor lights and switches using the Govee API.
+
+## Installation
+
+* The installation is done inside [HACS](https://hacs.xyz/) (Home Assistant Community Store). If you don't have HACS, you must install it before adding this integration. [Installation instructions here.](https://hacs.xyz/docs/use/download/download/)
+* Once HACS is installed, navigate to the 'Integrations' tab in HACS and search for the 'Govee' integration there. Click "Download this repository in HACS". On the next screen, select "Download". Once fully downloaded, restart HomeAssistant.
+* In the sidebar, click 'Configuration', then 'Devices & Services'. Click the + icon to add "Govee" to your Home Assistant installation. An API key
+is required, you need to obtain it in the 'Govee Home' app on your mobile device. This can be done from the Account Page (Far right icon at the bottom) > Settings (top right icon) > About Us > Apply for API Key. The key will be sent to your account email.
+
+## Sponsor
+
+A lot of effort is going into that integration. So if you can afford it and want to support us:
+
+<a href="https://www.buymeacoffee.com/theogre" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
+
+Thank you!
+
+## Is it stable?
+
+We think so. It is used often, and the support thread is active.
+
+![usage statistics per version](https://raw.githubusercontent.com/TheOneOgre/actions/main/output/goveestats_installations.png)
+
+Usage Data is taken from Home Assistant analytics, and plotted over time by us. You need to enable analytics if you want to show here.
+
+## Is there an issue right now?
+
+This graph uses the same library to do simple checks. If you see round dots on the right of the graph (= today), probably there is an issue.
+
+![Govee API running?](https://raw.githubusercontent.com/TheOneOgre/actions/main/output/govee-api-up.png)
+
+## Pulling or assuming state
+
+Some devices do not support pulling state. In this case we assume the state on your last input.
+For others, we assume the state just after controlling the light, but will otherwise request it from the cloud API.
+
+## DISABLING state updates for specific attributes
+
+You shouldn't use this feature in normal operation, but if something is broke e.g. on Govee API you could help yourself and others on the forum with a little tweak.
+
+Not all attribute updates can be disabled, but most can. Fiddling here could also lead to other misbehavours, but it could help with some issues.
+
+Let's talk about an example:
+
+### What if power_state isn't correctly returned from API?
+
+We can have state from two sources: 'API' and 'HISTORY'. History for example means, when we turn on a light we already guess the state will be on, so we set a history state of on before we get data from the API. In the default configuration you could also see this, as it shows two buttons until the final state from API arrives.
+
+![two-button-state](https://community-assets.home-assistant.io/original/3X/d/7/d7d2ee09520672e7671fdeed5bb461fcfaab8493.png)
+
+So let's say we have an issue, that the ON/OFF state from API is wrong, we always get OFF. (This happended, and this is why I developed that feature). If we disable the power state we get from API we could work around this, and thats exactly what we do:
+
+1. 'API' or 'History': state from which source do we want to disable? In our example the API state is wrong, as we could see in logs, so we choose 'API'
+2. Look up the attribute you want to disable in GoveeDevice data class. Don't worry, you don't need to understand any of the code here. [Here is that data class (click)](https://github.com/TheOneOgre/python-govee-api/blob/master/govee_api_laggat/govee_dtos.py). In our Example we will find 'power_state'
+3. Next, in Home Assistant we open Configuration - Integrations and click on the options on the Govee integration. Here is an example how this config option could look:
+
+![DISABLE state updates option](https://community-assets.home-assistant.io/original/3X/6/c/6cffe0de8b100ef4efc0e460482ff659b8f9444c.png)
+
+4. With the information from 1. and 2. we could write a string disabling power_state from API. This will do the trick for our case:
+```
+API:power_state
+```
+
+IF you want to disable a state from both sources, do that separately. You may have as many disables as you like.
+```
+API:online;HISTORY:online
+```
+
+[If you fix an issue like that, consider helping other users on the forum thread (click).](https://community.home-assistant.io/t/govee-integration/228516/438?u=laggat)
+
+ALWAYS REMEMBER: this should always be a temporarly workaround, if you use it in daily business you should probably request a feature or bug fix :)
+
+To remind you disabling it asap, this wil log a warning on every update.
+
+## What is config/govee_learning.yaml
+
+Usually you don't have to do anything here - just in case something feels wrong read on:
+
+```
+40:83:FF:FF:FF:FF:FF:FF:
+  set_brightness_max: 100
+  get_brightness_max: 100
+  before_set_brightness_turn_on: false
+  config_offline_is_off: false
+```
+
+Different Govee devices use different settings. These will be learned by the used library, or can be configured by you.
+
+* set_brightness_max: is autolearned, defines the range to set the brightness to 0-100 or 0-254.
+* get_brightness_max: is autolearned, defines the range how to interpet brightness state (also 0-100 or 0-254).
+* before_set_brightness_turn_on: Configurable by you, default false. When true, if the device is off and you set the brightness > 0 the device is turned on first, then after a second the brightness is set. Some device don't turn on with the set brightness command.
+* config_offline_is_off: Configurable by you, default false. This is useful if your device is e.g. powered by a TV's USB port, where when the TV is off, the LED is also off. Usually we stay in the state we know, this changes this to OFF state when the device disconnects.
+
+## Support
+
+Support thread is here: <https://community.home-assistant.io/t/govee-led-strips-integration/228516>
+There you'll also find links to code repositories and their issue trackers.
+
+For bug reports, include the debug log, which can be enabled in configuration YAML + restart:
+
+```YAML
+logger:
+  default: warning
+  logs:
+    homeassistant.components.govee: debug
+    custom_components.govee: debug
+    govee_api_laggat: debug
+```
+
+Then in Settings - Logs click on “full logs” button and add them to the bug report after removing personal data.
+
+## Caveats
+
+You can set a poll interval, but don't set it too low as the API has a limit of 60 requests per minute, and each device needs one request per state pull and control action.
+If you have more than one lamp use a higher interval. Govee wants to implement a single request for all devices in 2021.
+
+Once the integration is active, you will see all your registered devices, and may control on/off, brightness, color temperature and color.

--- a/custom_components/govee/__init__.py
+++ b/custom_components/govee/__init__.py
@@ -1,0 +1,65 @@
+"""The Govee integration."""
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .api import GoveeClient
+from .learning_storage import GoveeLearningStorage
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS: list[str] = ["light"]
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the Govee integration (YAML not supported)."""
+    hass.data.setdefault(DOMAIN, {})
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up Govee from a config entry."""
+
+    api_key = entry.options.get(CONF_API_KEY, entry.data.get(CONF_API_KEY, ""))
+
+    storage = GoveeLearningStorage(hass.config.config_dir, hass)
+    hub = await GoveeClient.create(api_key, storage, hass)
+
+
+    # New style: per entry_id
+    hass.data[DOMAIN][entry.entry_id] = {"hub": hub}
+    # Legacy style: global "hub" key
+    hass.data[DOMAIN]["hub"] = hub
+
+    devices, err = await hub.get_devices()
+    if err:
+        _LOGGER.warning("Could not connect to Govee API at startup: %s", err)
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    if unload_ok:
+        # New style cleanup
+        hub = hass.data[DOMAIN].get(entry.entry_id, {}).pop("hub", None)
+        if hub:
+            await hub.close()
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+
+        # Legacy cleanup
+        hass.data[DOMAIN].pop("hub", None)
+
+    return unload_ok
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Handle reload of a config entry."""
+    await async_unload_entry(hass, entry)
+    await async_setup_entry(hass, entry)

--- a/custom_components/govee/api.py
+++ b/custom_components/govee/api.py
@@ -1,0 +1,233 @@
+"""Minimal Govee API client."""
+import aiohttp
+import asyncio
+import certifi
+import logging
+import ssl
+import time
+from aiohttp import ClientSession
+from typing import Any, Dict, List, Tuple, Union
+
+from .models import GoveeDevice, GoveeSource, GoveeLearnedInfo
+
+_LOGGER = logging.getLogger(__name__)
+
+_API_BASE = "https://developer-api.govee.com/v1"
+_API_DEVICES = f"{_API_BASE}/devices"
+_API_CONTROL = f"{_API_BASE}/devices/control"
+
+
+class GoveeClient:
+    def __init__(self, api_key: str, storage):
+        self._api_key = api_key
+        self._storage = storage
+        self._devices: Dict[str, GoveeDevice] = {}
+        self._session: aiohttp.ClientSession | None = None
+        self._ssl_context: ssl.SSLContext | None = None  # define upfront
+
+        # rate limit
+        self._limit = 100
+        self._remaining = 100
+        self._reset = 0
+        self._rate_limit_on = 5
+
+    @classmethod
+    async def create(cls, api_key: str, storage, hass=None):
+        """Async-safe constructor."""
+        self = cls(api_key, storage)
+
+        # Async-safe SSL context creation
+        if hass is not None:
+            def _make_ssl():
+                return ssl.create_default_context(cafile=certifi.where())
+            self._ssl_context = await hass.async_add_executor_job(_make_ssl)
+        else:
+            self._ssl_context = ssl.create_default_context(cafile=certifi.where())
+
+        await self._init_session()
+        return self
+
+    async def _init_session(self):
+        """Initialize aiohttp session with SSL context."""
+        # Close existing session if already open (important for reloads)
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+        connector = aiohttp.TCPConnector(ssl=self._ssl_context)
+        self._session = ClientSession(connector=connector)
+
+
+    async def close(self):
+        """Gracefully close aiohttp session."""
+        if self._session and not self._session.closed:
+            await self._session.close()
+        self._session = None
+
+
+    def _headers(self):
+        return {"Govee-API-Key": self._api_key}
+
+    async def _rate_limit_delay(self):
+        if self._remaining <= self._rate_limit_on:
+            reset_in = max(0, self._reset - int(time.time()))
+            _LOGGER.warning("Rate limit reached, skipping updates for %ss", reset_in)
+            return []
+
+
+    def _track_rate_limit(self, response: aiohttp.ClientResponse):
+        if "Rate-Limit-Total" in response.headers:
+            try:
+                self._limit = int(response.headers["Rate-Limit-Total"])
+                self._remaining = int(response.headers["Rate-Limit-Remaining"])
+                self._reset = int(response.headers["Rate-Limit-Reset"])
+            except Exception:
+                self._remaining -= 1
+
+    async def get_devices(self) -> Tuple[List[GoveeDevice], str | None]:
+        await self._rate_limit_delay()
+        async with self._session.get(_API_DEVICES, headers=self._headers()) as resp:
+            self._track_rate_limit(resp)
+            if resp.status != 200:
+                return [], f"API error {resp.status}: {await resp.text()}"
+            data = await resp.json()
+            if "data" not in data or "devices" not in data["data"]:
+                return [], "Malformed API response"
+
+            timestamp = int(time.time())
+            learning_infos = await self._storage.read()
+
+            for item in data["data"]["devices"]:
+                dev_id = item["device"]
+                if dev_id in self._devices:
+                    continue
+                learned = learning_infos.get(dev_id, GoveeLearnedInfo())
+                self._devices[dev_id] = GoveeDevice(
+                    device=dev_id,
+                    model=item["model"],
+                    device_name=item["deviceName"],
+                    controllable=item["controllable"],
+                    retrievable=item["retrievable"],
+                    support_cmds=item["supportCmds"],
+                    support_turn="turn" in item["supportCmds"],
+                    support_brightness="brightness" in item["supportCmds"],
+                    support_color="color" in item["supportCmds"],
+                    support_color_temp="colorTem" in item["supportCmds"],
+                    online=True,
+                    timestamp=timestamp,
+                    source=GoveeSource.API,
+                    learned_set_brightness_max=learned.set_brightness_max,
+                    learned_get_brightness_max=learned.get_brightness_max,
+                    before_set_brightness_turn_on=learned.before_set_brightness_turn_on,
+                    config_offline_is_off=learned.config_offline_is_off,
+                )
+
+            return list(self._devices.values()), None
+
+    async def init_devices(self) -> Tuple[List[GoveeDevice], str | None]:
+        """Discover devices and fetch their initial state."""
+        devices, err = await self.get_devices()
+        if err:
+            return devices, err
+
+        # Fetch live state for each device
+        for dev in devices:
+            ok, state_err = await self.get_device_state(dev.device)
+            if not ok and state_err:
+                _LOGGER.warning("Failed to fetch initial state for %s: %s", dev.device, state_err)
+
+        return list(self._devices.values()), None
+
+
+    async def _control(self, device: Union[str, GoveeDevice], command: str, value: Any) -> Tuple[bool, str | None]:
+        if isinstance(device, str):
+            device = self._devices.get(device)
+        if not device:
+            return False, f"Unknown device {device}"
+        if not device.controllable:
+            return False, f"Device {device.device} not controllable"
+        if command not in device.support_cmds:
+            return False, f"Command {command} not supported"
+
+        payload = {
+            "device": device.device,
+            "model": device.model,
+            "cmd": {"name": command, "value": value},
+        }
+
+        await self._rate_limit_delay()
+        async with self._session.put(_API_CONTROL, headers=self._headers(), json=payload) as resp:
+            self._track_rate_limit(resp)
+
+            if resp.status == 429:
+                retry = max(0, self._reset - int(time.time()))
+                _LOGGER.warning("Rate limited for %s: retry after %ss", device.device, retry)
+                # Soft success → let HA trust local state
+                return True, f"Rate limit: assumed success, retry in {retry}s"
+
+            if resp.status != 200:
+                return False, f"API error {resp.status}: {await resp.text()}"
+
+            result = await resp.json()
+            return result.get("message") == "Success", None
+
+
+
+
+    async def turn_on(self, device):
+        return await self._control(device, "turn", "on")
+
+    async def turn_off(self, device):
+        return await self._control(device, "turn", "off")
+
+    async def set_brightness(self, device, value: int):
+        # Convert 0–255 (HA) → 0–100 (Govee API)
+        percent = max(0, min(100, round(value / 255 * 100)))
+        return await self._control(device, "brightness", percent)
+
+    async def set_color_temp(self, device, value: int):
+        # Clamp to Govee’s supported Kelvin range
+        kelvin = max(2700, min(9000, value))
+        return await self._control(device, "colorTem", kelvin)
+
+    async def set_color(self, device, rgb: Tuple[int, int, int]):
+        # Defensive: only send if supported
+        if "color" not in device.support_cmds:
+            return False, "Device does not support color"
+        return await self._control(device, "color", {
+            "r": rgb[0],
+            "g": rgb[1],
+            "b": rgb[2]
+        })
+
+    async def get_device_state(self, device_id: str) -> Tuple[bool, str | None]:
+        """Fetch current state of a device via API."""
+        payload = {"device": device_id, "model": self._devices[device_id].model}
+        await self._rate_limit_delay()
+        async with self._session.get(f"{_API_BASE}/devices/state", headers=self._headers(), params=payload) as resp:
+            self._track_rate_limit(resp)
+            if resp.status != 200:
+                return False, f"API error {resp.status}: {await resp.text()}"
+            data = await resp.json()
+            if "data" not in data or "properties" not in data["data"]:
+                return False, "Malformed state response"
+
+            props = data["data"]["properties"]
+            dev = self._devices[device_id]
+            for p in props:
+                # Some properties objects don’t have "online"
+                if "online" in p and p["online"] is False:
+                    dev.online = False
+                if p.get("powerState") == "on":
+                    dev.power_state = True
+                if p.get("powerState") == "off":
+                    dev.power_state = False
+                if "brightness" in p:
+                    dev.brightness = p["brightness"]
+                if "color" in p:
+                    c = p["color"]
+                    dev.color = (c["r"], c["g"], c["b"])
+                if "colorTemInKelvin" in p:
+                    dev.color_temp = p["colorTemInKelvin"]
+            dev.online = True
+
+            return True, None

--- a/custom_components/govee/config_flow.py
+++ b/custom_components/govee/config_flow.py
@@ -1,0 +1,169 @@
+"""Config flow for Govee integration."""
+
+import logging
+import voluptuous as vol
+
+from homeassistant import config_entries, core, exceptions
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_API_KEY, CONF_DELAY, CONF_SCAN_INTERVAL
+from homeassistant.core import callback
+
+from .const import (
+    CONF_DISABLE_ATTRIBUTE_UPDATES,
+    CONF_OFFLINE_IS_OFF,
+    CONF_USE_ASSUMED_STATE,
+    DOMAIN,
+)
+
+from .api import GoveeClient
+from .learning_storage import GoveeLearningStorage
+
+
+
+_LOGGER = logging.getLogger(__name__)
+CONF_POLLING_MODE = "polling_mode"   # "auto" or "manual"
+DEFAULT_SCAN_INTERVAL = 60
+
+async def validate_api_key(hass: core.HomeAssistant, user_input: dict):
+    """Validate that the API key works by attempting to fetch devices."""
+    api_key = user_input[CONF_API_KEY]
+    hub = await GoveeClient.create(api_key, GoveeLearningStorage(hass.config.config_dir, hass))
+    devices, error = await hub.get_devices()
+    await hub.close()
+
+    if error:
+        raise CannotConnect(error)
+
+    return user_input
+
+
+async def validate_disabled_attribute_updates(hass: core.HomeAssistant, user_input: dict):
+    """Validate the ignore_device_attributes string (placeholder for future use)."""
+    disable_str = user_input.get(CONF_DISABLE_ATTRIBUTE_UPDATES, "")
+    if disable_str and not isinstance(disable_str, str):
+        raise CannotConnect("Invalid disabled attributes format")
+    return user_input
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class GoveeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Govee."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}
+        if user_input is not None:
+            try:
+                user_input = await validate_api_key(self.hass, user_input)
+            except CannotConnect as conn_ex:
+                _LOGGER.exception("Cannot connect: %s", conn_ex)
+                errors[CONF_API_KEY] = "cannot_connect"
+            except Exception as ex:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception: %s", ex)
+                errors["base"] = "unknown"
+
+            if not errors:
+                return self.async_create_entry(title="Govee", data=user_input)
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_API_KEY): cv.string,
+                    vol.Optional(CONF_DELAY, default=10): cv.positive_int,
+                }
+            ),
+            errors=errors,
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow."""
+        return GoveeOptionsFlowHandler(config_entry)
+
+
+class GoveeOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options."""
+
+    VERSION = 1
+
+    def __init__(self, config_entry):
+        self.config_entry = config_entry
+        self.options = dict(config_entry.options)
+
+    async def async_step_init(self, user_input=None):
+        return await self.async_step_user(user_input)
+
+    async def async_step_user(self, user_input=None):
+        old_api_key = self.config_entry.options.get(
+            CONF_API_KEY, self.config_entry.data.get(CONF_API_KEY, "")
+        )
+        errors = {}
+
+        if user_input is not None:
+            try:
+                api_key = user_input[CONF_API_KEY]
+                if old_api_key != api_key:
+                    user_input = await validate_api_key(self.hass, user_input)
+
+                user_input = await validate_disabled_attribute_updates(self.hass, user_input)
+            except CannotConnect as conn_ex:
+                _LOGGER.exception("Cannot connect: %s", conn_ex)
+                errors[CONF_API_KEY] = "cannot_connect"
+            except Exception as ex:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception: %s", ex)
+                errors["base"] = "unknown"
+
+            if not errors:
+                self.options.update(user_input)
+                return self.async_create_entry(title="Govee", data=self.options)
+
+        # Build schema every time (not just on error)
+        options_schema = vol.Schema(
+            {
+                vol.Required(CONF_API_KEY, default=old_api_key): cv.string,
+                vol.Optional(
+                    CONF_DELAY,
+                    default=0,  # default = auto
+                    description={"note": "{polling_note}"}
+                ): cv.positive_int,
+                vol.Required(
+                    CONF_USE_ASSUMED_STATE,
+                    default=self.config_entry.options.get(CONF_USE_ASSUMED_STATE, True),
+                ): cv.boolean,
+                vol.Required(
+                    CONF_OFFLINE_IS_OFF,
+                    default=self.config_entry.options.get(CONF_OFFLINE_IS_OFF, False),
+                ): cv.boolean,
+                vol.Optional(
+                    CONF_DISABLE_ATTRIBUTE_UPDATES,
+                    default=self.config_entry.options.get(CONF_DISABLE_ATTRIBUTE_UPDATES, ""),
+                ): cv.string,
+            }
+        )
+
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=options_schema,
+            errors=errors,
+            description_placeholders={
+                "polling_note": (
+                    "ℹ️ Set to **0** for automatic interval adjustment (recommended). "
+                    "Manual values are allowed, but note: the Govee API allows only "
+                    "**10,000 requests per day**. Too small a value may cause rate limiting."
+                )
+            },
+        )
+
+
+
+
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""

--- a/custom_components/govee/const.py
+++ b/custom_components/govee/const.py
@@ -1,0 +1,11 @@
+"""Constants for the Govee LED strips integration."""
+
+DOMAIN = "govee"
+
+CONF_DISABLE_ATTRIBUTE_UPDATES = "disable_attribute_updates"
+CONF_OFFLINE_IS_OFF = "offline_is_off"
+CONF_USE_ASSUMED_STATE = "use_assumed_state"
+
+COLOR_TEMP_KELVIN_MIN = 2000
+COLOR_TEMP_KELVIN_MAX = 9000
+CONF_POLLING_MODE = "polling_mode"

--- a/custom_components/govee/learning_storage.py
+++ b/custom_components/govee/learning_storage.py
@@ -1,0 +1,48 @@
+"""The Govee learned storage yaml file manager."""
+
+from dataclasses import asdict
+import logging
+import dacite
+import yaml
+
+from homeassistant.util.yaml import load_yaml, save_yaml
+from .models import GoveeLearnedInfo
+
+_LOGGER = logging.getLogger(__name__)
+LEARNING_STORAGE_YAML = "/govee_learning.yaml"
+
+
+class GoveeLearningStorage:
+    def __init__(self, config_dir, hass):
+        self._config_dir = config_dir
+        self._hass = hass
+
+    async def read(self):
+        path = self._config_dir + LEARNING_STORAGE_YAML
+
+        def _blocking_read():
+            return load_yaml(path)
+
+        learned_info = {}
+        try:
+            learned_dict = await self._hass.async_add_executor_job(_blocking_read)
+            learned_info = {
+                dev: dacite.from_dict(GoveeLearnedInfo, learned_dict[dev])
+                for dev in learned_dict
+            }
+        except FileNotFoundError:
+            _LOGGER.info("No learned info file yet, starting fresh")
+        except Exception as ex:
+            _LOGGER.warning("Invalid learned info file %s: %s", path, ex)
+
+        return learned_info
+
+    async def write(self, learned_info):
+        path = self._config_dir + LEARNING_STORAGE_YAML
+        learned_dict = {dev: asdict(learned_info[dev]) for dev in learned_info}
+
+        def _blocking_write():
+            save_yaml(path, learned_dict)
+
+        await self._hass.async_add_executor_job(_blocking_write)
+        _LOGGER.info("Stored learning information to %s", path)

--- a/custom_components/govee/light.py
+++ b/custom_components/govee/light.py
@@ -1,0 +1,293 @@
+"""Govee light platform."""
+import logging
+from datetime import datetime, timedelta
+
+from homeassistant.util import color
+from homeassistant.util.color import value_to_brightness
+from homeassistant.const import CONF_DELAY
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP_KELVIN,
+    ATTR_HS_COLOR,
+    ColorMode,
+    LightEntity,
+)
+
+from propcache import cached_property
+from .const import (
+    DOMAIN,
+    CONF_OFFLINE_IS_OFF,
+    CONF_USE_ASSUMED_STATE,
+    CONF_POLLING_MODE, 
+    COLOR_TEMP_KELVIN_MIN,
+    COLOR_TEMP_KELVIN_MAX,
+)
+from .api import GoveeClient
+from .models import GoveeDevice, GoveeSource
+
+_LOGGER = logging.getLogger(__name__)
+
+
+DEFAULT_SCAN_INTERVAL = 60  # safe fallback
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the Govee Light platform."""
+    _LOGGER.debug("Setting up Govee lights")
+    config = entry.data
+    options = entry.options
+    entry_data = hass.data[DOMAIN].get(entry.entry_id) or hass.data[DOMAIN]
+    hub = entry_data["hub"]
+
+    # Work out polling mode and delay
+    mode = options.get(CONF_POLLING_MODE, "auto")
+    delay = options.get(CONF_DELAY, config.get(CONF_DELAY, 0))
+
+    if delay == 0:
+        # Auto calculation: use count of devices to pick safe interval
+        tmp_devices, _ = await hub.get_devices()
+        num_devices = max(1, len(tmp_devices))
+        delay = max(30, int(86400 / (10000 / num_devices)))  # safe under 10k/day
+
+    if mode == "auto":
+        tmp_devices, _ = await hub.get_devices()
+        device_count = max(1, len(tmp_devices))
+        safe_delay = max(30, int(86400 * device_count / 10000))  # 10k/day quota
+        update_interval = timedelta(seconds=safe_delay)
+        _LOGGER.warning(
+            "Polling mode AUTO: %s devices → interval set to %ss (safe under 10k/day quota).",
+            device_count,
+            safe_delay,
+        )
+    else:  # manual mode
+        update_interval = timedelta(seconds=delay)
+        _LOGGER.warning(
+            "Polling mode MANUAL: interval set to %ss. Ensure this does not exceed 10k/day quota.",
+            delay,
+        )
+
+    # Coordinator drives updates
+    coordinator = GoveeDataUpdateCoordinator(
+        hass, _LOGGER, hub, update_interval=update_interval, config_entry=entry
+    )
+
+    # Fetch initial devices with full state (calls /devices/state once each)
+    devices, _ = await hub.init_devices()
+
+    # Prime the coordinator with that data
+    coordinator.data = devices
+
+
+    # Register light entities with fresh data
+    entities = [GoveeLightEntity(hub, entry.title, coordinator, dev) for dev in devices]
+    async_add_entities(entities, update_before_add=True)
+
+
+
+
+class GoveeDataUpdateCoordinator(DataUpdateCoordinator):
+    """Device state update handler."""
+
+    def __init__(self, hass, logger, hub: GoveeClient, update_interval=None, *, config_entry):
+        self._config_entry = config_entry
+        self._hub = hub
+        super().__init__(
+            hass,
+            logger,
+            name=DOMAIN,
+            update_interval=update_interval,
+            update_method=self._async_update,
+        )
+
+    @property
+    def use_assumed_state(self):
+        return self._config_entry.options.get(CONF_USE_ASSUMED_STATE, True)
+
+    @property
+    def config_offline_is_off(self):
+        return self._config_entry.options.get(CONF_OFFLINE_IS_OFF, False)
+
+    async def _async_update(self):
+        """Fetch data from Govee API."""
+        try:
+            devices, err = await self._hub.get_devices()
+            if err:
+                raise UpdateFailed(err)
+            return devices
+        except Exception as ex:
+            raise UpdateFailed(f"Exception on getting states: {ex}") from ex
+
+
+class GoveeLightEntity(LightEntity):
+    """Representation of a Govee light."""
+
+    def __init__(self, hub: GoveeClient, title: str, coordinator: GoveeDataUpdateCoordinator, device: GoveeDevice):
+        self._hub = hub
+        self._title = title
+        self._coordinator = coordinator
+        self._device_id = device.device  # store only ID
+
+    @property
+    def _device(self) -> GoveeDevice | None:
+        """Always return the current device object from coordinator.data."""
+        if not self._coordinator.data:
+            return None
+        return next((d for d in self._coordinator.data if d.device == self._device_id), None)
+
+    async def async_added_to_hass(self):
+        self._coordinator.async_add_listener(self.async_write_ha_state)
+
+    @property
+    def is_on(self):
+        dev = self._device
+        return dev.power_state if dev else False
+
+    @property
+    def brightness(self):
+        dev = self._device
+        return dev.brightness if dev and dev.support_brightness else None
+
+    @property
+    def hs_color(self):
+        dev = self._device
+        return color.color_RGB_to_hs(*dev.color) if dev and dev.support_color else None
+
+    @property
+    def rgb_color(self):
+        dev = self._device
+        return list(dev.color) if dev and dev.support_color else None
+
+    @property
+    def color_temp_kelvin(self):
+        dev = self._device
+        return dev.color_temp if dev and dev.support_color_temp else None
+
+    @property
+    def supported_color_modes(self) -> set[ColorMode]:
+        dev = self._device
+        if not dev:
+            return {ColorMode.ONOFF}
+
+        modes = set()
+        if dev.support_color:
+            modes.add(ColorMode.HS)
+        if dev.support_color_temp:
+            modes.add(ColorMode.COLOR_TEMP)
+        if dev.support_brightness and not (dev.support_color or dev.support_color_temp):
+            # brightness-only (like dimmers without color)
+            modes.add(ColorMode.BRIGHTNESS)
+        if not modes:
+            modes.add(ColorMode.ONOFF)
+        return modes
+
+
+    @property
+    def color_mode(self) -> ColorMode:
+        dev = self._device
+        if not dev:
+            return ColorMode.ONOFF
+
+        # Prioritize based on what’s actually supported
+        if dev.support_color and dev.color and any(dev.color):
+            return ColorMode.HS
+        if dev.support_color_temp and dev.color_temp > 0:
+            return ColorMode.COLOR_TEMP
+        if dev.support_brightness:
+            return ColorMode.BRIGHTNESS
+        return ColorMode.ONOFF
+
+
+    async def async_turn_on(self, **kwargs):
+        dev = self._device
+        if not dev:
+            return
+
+        err = None
+        ok = False
+
+        if ATTR_HS_COLOR in kwargs and dev.support_color:
+            hs_color = kwargs[ATTR_HS_COLOR]
+            col = color.color_hs_to_RGB(hs_color[0], hs_color[1])
+            ok, err = await self._hub.set_color(dev, col)
+            # Trust local update even if rate limited
+            if ok or (err and "Rate limit" in err):
+                dev.color = col
+                dev.power_state = True
+
+        elif ATTR_BRIGHTNESS in kwargs and dev.support_brightness:
+            ha_bright = kwargs[ATTR_BRIGHTNESS]  # 0–255 from HA
+            ok, err = await self._hub.set_brightness(dev, ha_bright)
+            if ok:
+                # store the HA-side brightness so the UI reflects it immediately
+                dev.brightness = ha_bright
+                dev.power_state = True
+
+
+        elif ATTR_COLOR_TEMP_KELVIN in kwargs and dev.support_color_temp:
+            color_temp = kwargs[ATTR_COLOR_TEMP_KELVIN]
+            color_temp = max(COLOR_TEMP_KELVIN_MIN, min(COLOR_TEMP_KELVIN_MAX, color_temp))
+            ok, err = await self._hub.set_color_temp(dev, color_temp)
+            if ok or (err and "Rate limit" in err):
+                dev.color_temp = color_temp
+                dev.power_state = True
+
+        else:
+            ok, err = await self._hub.turn_on(dev)
+            if ok or (err and "Rate limit" in err):
+                dev.power_state = True
+
+        # Always push local state if we considered it valid
+        if ok or (err and "Rate limit" in err):
+            self.async_write_ha_state()
+        else:
+            _LOGGER.warning("async_turn_on failed for %s: %s", dev.device, err)
+
+
+
+    async def async_turn_off(self, **kwargs):
+        dev = self._device
+        if not dev:
+            return
+        ok, err = await self._hub.turn_off(dev)
+        if ok:
+            dev.power_state = False
+            self.async_write_ha_state()
+        else:
+            _LOGGER.warning("async_turn_off failed for %s: %s", dev.device, err)
+
+
+
+    @property
+    def name(self):
+        dev = self._device
+        return dev.device_name if dev else "Unknown"
+
+    @property
+    def unique_id(self):
+        return f"govee_{self._title}_{self._device_id}"
+
+    @property
+    def device_info(self):
+        dev = self._device
+        return {
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "name": dev.device_name if dev else "Unknown",
+            "manufacturer": "Govee",
+            "model": dev.model if dev else "Unknown",
+        }
+
+    @property
+    def available(self):
+        dev = self._device
+        return dev.online if dev else False
+
+    @property
+    def assumed_state(self):
+        dev = self._device
+        return (
+            self._coordinator.use_assumed_state
+            and dev
+            and dev.source == GoveeSource.HISTORY
+        )

--- a/custom_components/govee/manifest.json
+++ b/custom_components/govee/manifest.json
@@ -1,0 +1,19 @@
+{
+  "domain": "govee",
+  "name": "Govee",
+  "codeowners": [
+    "@TheOneOgre"
+  ],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/TheOneOgre/govee-cloud/blob/master/README.md",
+  "homekit": {},
+  "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/TheOneOgre/govee-cloud/issues",
+  "requirements": [
+    "dacite==1.8.0"
+  ],
+  "ssdp": [],
+  "version": "0.2.1",
+  "zeroconf": []
+}

--- a/custom_components/govee/models.py
+++ b/custom_components/govee/models.py
@@ -1,0 +1,45 @@
+"""Models for Govee integration."""
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Tuple, Optional
+
+
+class GoveeSource(Enum):
+    HISTORY = "history"
+    API = "api"
+
+
+@dataclass
+class GoveeDevice:
+    device: str
+    model: str
+    device_name: str
+    controllable: bool
+    retrievable: bool
+    support_cmds: List[str]
+    support_turn: bool
+    support_brightness: bool
+    support_color: bool
+    support_color_temp: bool
+    online: bool = False
+    power_state: bool = False
+    brightness: int = 0
+    color: Tuple[int, int, int] = (0, 0, 0)
+    color_temp: int = 0
+    timestamp: int = 0
+    source: GoveeSource = GoveeSource.HISTORY
+    error: Optional[str] = None
+    learned_set_brightness_max: Optional[int] = None
+    learned_get_brightness_max: Optional[int] = None
+    before_set_brightness_turn_on: bool = False
+    config_offline_is_off: bool = False
+    lock_set_until: int = 0
+    lock_get_until: int = 0
+
+
+@dataclass
+class GoveeLearnedInfo:
+    set_brightness_max: Optional[int] = None
+    get_brightness_max: Optional[int] = None
+    before_set_brightness_turn_on: bool = False
+    config_offline_is_off: bool = False

--- a/custom_components/govee/translations/en.json
+++ b/custom_components/govee/translations/en.json
@@ -1,0 +1,42 @@
+{
+  "title": "Govee",
+  "config": {
+    "abort": {
+      "already_configured": "Already configured. Only a single configuration possible."
+    },
+    "error": {
+      "cannot_connect": "Cannot connect. Is the API-Key correct and the internet connection working?",
+      "unknown": "Unknown Error."
+    },
+    "step": {
+      "user": {
+        "data": {
+          "api_key": "API Key",
+          "delay": "Polling Interval (set to 0 for auto)"
+        },
+        "title": "Setup",
+        "description": "For details on obtaining an API key see: https://github.com/TheOneOgre/govee-cloud/blob/master/README.md"
+      }
+    }
+  },
+  "options": {
+    "error": {
+      "cannot_connect": "Cannot connect. Is the API-Key correct and the internet connection working?",
+      "unknown": "Unknown Error.",
+      "disabled_attribute_updates_wrong": "Wrong format, see README above."
+    },
+    "step": {
+      "user": {
+      "data": {
+        "api_key": "API Key (requires restart)",
+        "delay": "Polling Interval (0 = auto; API limit 10,000/day, requires restart)",
+        "use_assumed_state": "Use 'assumed state' (two buttons). Default: True",
+        "offline_is_off": "When a LED is offline, show it as off (default doesn’t change state). Default: False",
+        "disable_attribute_updates": "DISABLE state updates. Space to disable. Read the README above!"
+      },
+        "title": "Options",
+        "description": "For more details see the README: https://github.com/TheOneOgre/govee-cloud/blob/master/README.md"
+      }
+    }
+  }
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,4 @@
+{
+    "name": "govee",
+    "homeassistant": "2025.6.1"
+}


### PR DESCRIPTION
_Originally posted by @TheOneOgre in [#236](https://github.com/LaggAt/hacs-govee/issues/236#issuecomment-3094629346)_

I have created this pull request so that others are aware and can submit their pull requests to the new repository so fixes can be integrated and this integration can continue moving forward.

I have [forked the repository](https://github.com/TheOneOgre/govee-cloud) and added/am adding collaborators to it so this doesn't happen again. I have made a https://github.com/hacs/default/pull/3700 as well as https://github.com/issues/created?issue=hacs%7Cintegration%7C4681 so it can be replaced with my own (or someone else's). I am awaiting [@ludeeus](https://github.com/ludeeus) to approve the PR and resolve the issue, but haven't had feedback yet. Maybe if someone can give these thumbs up/replies/interaction to get it moving forward so that others can have this resolved automatically in the future, that would be great!

As for now, if you would like to use this as your current integration, the easiest way is to follow these steps, and requires no reconfiguration:

Go to your Home Assistant Dashboard, go to HACS on the left tab, click the kebab menu in the top right (3 vertical dots), click "Custom repositories"

Use TheOneOgre/govee-cloud in the "Repository" field, select Type: Integration, then click "Add".

Remove the integration you have installed from either HACS>govee (LaggAt Version)>kebab menu> "Remove", and it will notify you: "Integration is configured. The govee integration is configured or ignored. You need to delete the configuration for it before removing it from HACS."

Click "Ignore", then "Remove", (do not reboot after, this will keep the integration configuration so when you add mine it will not need reconfiguration). Then go back to HACS integration lists, find "govee" (at the time of writing mine has 11 stars and activity a few minutes ago as I just made a new release from dev>master) and make sure at the top of the integration information page it shows "TheOneOgre" and click download.

Restart HA after downloading, and your integration should still be enabled and now working with no reconfiguration! This will also persist across reboots, upgrades, and other HA changes as normal.

If you have any issues or wish to help with the project or getting the repository added/changed in HACS, let me know!